### PR TITLE
减少 RecipeChainIterator 中对待处理依赖的重复扫描

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/bookmarks/chain/RecipeChainIterator.java
+++ b/Gui/src/main/java/mezz/jei/gui/bookmarks/chain/RecipeChainIterator.java
@@ -58,6 +58,13 @@ public final class RecipeChainIterator implements Iterator<Map<ResourceLocation,
 		});
 		preferredItems.keySet().removeIf(item -> !hasCalculatedAmount(item, details));
 
+		Set<RecipeChainInput> referencedByPendingRecipes = new HashSet<>();
+		for (Map.Entry<RecipeChainInput, RecipeChainInput> entry : preferredItems.entrySet()) {
+			if (!this.processedRecipes.contains(entry.getKey().metadata().recipeUid())) {
+				referencedByPendingRecipes.add(entry.getValue());
+			}
+		}
+
 		for (Map.Entry<RecipeChainInput, RecipeChainInput> entry : preferredItems.entrySet()) {
 			RecipeChainInput keyItem = entry.getKey();
 			ResourceLocation keyRecipe = keyItem.metadata().recipeUid();
@@ -68,10 +75,7 @@ public final class RecipeChainIterator implements Iterator<Map<ResourceLocation,
 					continue;
 				}
 
-				if (preferredItems.entrySet().stream().anyMatch(pref ->
-					!this.processedRecipes.contains(pref.getKey().metadata().recipeUid()) &&
-						item.equals(pref.getValue())
-				)) {
+				if (referencedByPendingRecipes.contains(item)) {
 					skipRecipes.add(itemRecipe);
 				} else {
 					long multiplier = details.calculatedItems()

--- a/Gui/src/test/java/mezz/jei/test/gui/bookmarks/RecipeChainIteratorTest.java
+++ b/Gui/src/test/java/mezz/jei/test/gui/bookmarks/RecipeChainIteratorTest.java
@@ -5,6 +5,8 @@ import mezz.jei.gui.bookmarks.chain.RecipeChainMath;
 import net.minecraft.resources.ResourceLocation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.Map;
@@ -75,6 +77,34 @@ public class RecipeChainIteratorTest {
 		));
 
 		Assertions.assertEquals(Map.of(TABLE_RECIPE, 1L, TORCH_RECIPE, 1L), iterator.next());
+		Assertions.assertEquals(Map.of(), iterator.next());
+		Assertions.assertFalse(iterator.hasNext());
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	public void iteratorDefersSharedDependencyOnlyWhileAnotherConsumerNeedsCrafting(boolean torchInInventory) {
+		RecipeChainMath math = RecipeChainMath.of(List.of(
+			input(0, result(TABLE_RECIPE, key("table"), 1, 1)),
+			input(1, ingredient(TABLE_RECIPE, key("stick"), 2)),
+			input(2, ingredient(TABLE_RECIPE, key("torch"), 1)),
+			input(3, result(TORCH_RECIPE, key("torch"), 1, 1)),
+			input(4, ingredient(TORCH_RECIPE, key("stick"), 3)),
+			input(5, result(STICK_RECIPE, key("stick"), 1, 1)),
+			input(6, ingredient(STICK_RECIPE, key("plank"), 1))
+		), Set.of());
+		math.createMasterRoot();
+
+		RecipeChainIterator iterator = new RecipeChainIterator(math, List.of());
+		iterator.updateInventory(torchInInventory
+			? List.of(input(100, item(key("torch"), 1)))
+			: List.of());
+
+		Assertions.assertEquals(Map.of(TABLE_RECIPE, 1L), iterator.next());
+		if (!torchInInventory) {
+			Assertions.assertEquals(Map.of(TORCH_RECIPE, 1L), iterator.next());
+		}
+		Assertions.assertEquals(Map.of(STICK_RECIPE, torchInInventory ? 2L : 5L), iterator.next());
 		Assertions.assertEquals(Map.of(), iterator.next());
 		Assertions.assertFalse(iterator.hasNext());
 	}


### PR DESCRIPTION
`RecipeChainIterator.next()` 当前会针对每个候选项，重新扫描经过筛选的首选结果映射，以判断是否仍有未处理的使用方引用该结果。本次修改在每次 `next()` 调用中预先收集这些引用，并在原有遍历中通过集合查询。对于筛选后的 P 条关系，在键的哈希与相等性判断成本有界的前提下，这部分处理从最坏 O(P²) 降为期望 O(P)，代价是 O(P) 的临时空间。

集合在现有需求筛选之后、`processedRecipes` 更新之前构建，保留完整的 `RecipeChainInput` 相等性语义，外层遍历、批量合并及状态更新均不变。新增的参数化测试覆盖两种情况：共享依赖需要等到另一个使用方被遍历后再处理；若该使用方的产物已在库存中，则不需要等待。这两个案例在原实现上也均通过。

验证结果：

- 46 项相关测试通过，涉及 `RecipeChainIteratorTest`、`RecipeChainMathTest`、`RecipeChainGraphTest`、`RecipeChainPlanTest` 和 `AutoCraftingManagerTest`。
- 更新后的迭代器测试类在修改生产代码之前也已通过全部 6 个案例。
- 使用临时初始化脚本限定任务输入后，两份修改文件的 Spotless 格式化与检查通过；未修改仓库构建配置。`git diff --check` 通过。
- 已尝试全仓库 `spotlessApply` 和 `spotlessCheck`，两者均被以下六份未修改测试中已有的通配符导入阻挡：`ConfigDraftTest`、`RecipeTreeInputTest`、`RecipeTreeLayoutTest`、`RecipeTreeSidebarLayoutTest`、`RecipeTreeSummaryTest` 和 `ConfigValueReloadTest`。

```sh
./gradlew :Gui:test --tests '*RecipeChainIteratorTest' --tests '*RecipeChainMathTest' --tests '*RecipeChainGraphTest' --tests '*RecipeChainPlanTest' --tests '*AutoCraftingManagerTest' --configure-on-demand --no-daemon --console=plain
```

未进行端到端性能基准测试或 GameTest；上述复杂度说明仅限于这一成员判断步骤。
